### PR TITLE
Take exec comm str to set child thread's comm when handling thread__fork event

### DIFF
--- a/tools/perf/util/thread.c
+++ b/tools/perf/util/thread.c
@@ -412,7 +412,7 @@ static int thread__clone_maps(struct thread *thread, struct thread *parent, bool
 int thread__fork(struct thread *thread, struct thread *parent, u64 timestamp, bool do_maps_clone)
 {
 	if (parent->comm_set) {
-		const char *comm = thread__comm_str(parent);
+		const char *comm = thread__exec_comm_str(parent);
 		int err;
 		if (!comm)
 			return -ENOMEM;


### PR DESCRIPTION
Set forked thread's comm to the discovered executable's comm to keep forked process relation to original process.